### PR TITLE
Extend possible number of ports per port/interface combination

### DIFF
--- a/accept-guard.c
+++ b/accept-guard.c
@@ -36,7 +36,7 @@
 #define ACL_ENV     "ACCEPT_GUARD_ACL"
 #define IFACE_ANY   "any"
 #define MAX_IFACES  (64 * 4)
-#define MAX_PORTS   2
+#define MAX_PORTS   8
 
 struct acl {
 	char iface[IF_NAMESIZE];


### PR DESCRIPTION
At the moment, it's set to 2 tcp/udp ports per interface but we're in the need of more.

Bump this arbitrarily up to 8 for the moment.